### PR TITLE
Cleanup event generics

### DIFF
--- a/src/plugins/WebOfTrust/EventSource.java
+++ b/src/plugins/WebOfTrust/EventSource.java
@@ -32,9 +32,11 @@ import plugins.WebOfTrust.SubscriptionManager.Subscription;
  * is about.
  */
 public interface EventSource extends Cloneable, Serializable {
-    
-    /** {@inheritDoc} */
-    public EventSource clone(); // Override because it is not public in class Object.
+
+    /**
+     * Provides a clone of this event source. Implementations must return {@code this.clone()}.
+     */
+    public EventSource cloned();
     
     /**
      * When a {@link Notification} about an {@link EventSource} is being deployed to a

--- a/src/plugins/WebOfTrust/Identity.java
+++ b/src/plugins/WebOfTrust/Identity.java
@@ -1005,8 +1005,14 @@ public class Identity extends Persistent implements Cloneable, EventSource {
 			throw new IllegalStateException(e); 
 		}
 	}
-	
 
+	/**
+	 * @see Identity#clone()
+	 */
+	@Override
+	public Identity cloned() {
+		return clone();
+	}
 	
 	/**
 	 * Stores this identity in the database without committing the transaction

--- a/src/plugins/WebOfTrust/Score.java
+++ b/src/plugins/WebOfTrust/Score.java
@@ -390,6 +390,14 @@ public final class Score extends Persistent implements Cloneable, EventSource {
 		return clone;
 	}
 
+	/**
+	 * @see Score#clone()
+	 */
+	@Override
+	public Score cloned() {
+		return clone();
+	}
+
 	@Override
 	public void startupDatabaseIntegrityTest() throws Exception {
 		activateFully();

--- a/src/plugins/WebOfTrust/Trust.java
+++ b/src/plugins/WebOfTrust/Trust.java
@@ -418,6 +418,14 @@ public final class Trust extends Persistent implements Cloneable, EventSource {
 		}
 	}
 
+	/**
+	 * @see Trust#clone()
+	 */
+	@Override
+	public Trust cloned() {
+		return clone();
+	}
+
 	@Override
 	public void startupDatabaseIntegrityTest() throws Exception {
 		activateFully();

--- a/src/plugins/WebOfTrust/ui/fcp/FCPInterface.java
+++ b/src/plugins/WebOfTrust/ui/fcp/FCPInterface.java
@@ -1216,7 +1216,7 @@ public final class FCPInterface implements FredPluginFCPMessageHandler.ServerSid
     	
     	try {
             FCPPluginMessage reply = FCPPluginMessage.constructSuccessReply(message);
-            Subscription<? extends EventSource> subscription;
+            Subscription<?> subscription;
             
 	    	if(to.equals("Identities")) {
 	    		subscription = mSubscriptionManager.subscribeToIdentities(client.getID());
@@ -1280,13 +1280,13 @@ public final class FCPInterface implements FredPluginFCPMessageHandler.ServerSid
             throws InvalidParameterException, UnknownSubscriptionException {
         
         final String subscriptionID = getMandatoryParameter(request.params, "SubscriptionID");
-    	final Class<Subscription<? extends EventSource>> clazz
+    	final Class<? extends Subscription> clazz
     	    = mSubscriptionManager.unsubscribe(subscriptionID);
         return handleUnsubscribe(request, clazz, subscriptionID);
     }
     
     public void sendUnsubscribedMessage(final UUID clientID,
-            final Class<Subscription<? extends EventSource>> clazz, final String subscriptionID)
+            final Class<? extends Subscription> clazz, final String subscriptionID)
                 throws IOException {
         
         mPluginRespirator.getPluginClientByID(clientID).send(SendDirection.ToClient,
@@ -1302,7 +1302,8 @@ public final class FCPInterface implements FredPluginFCPMessageHandler.ServerSid
      *            due to an original client message.
      */
     private FCPPluginMessage handleUnsubscribe(final FCPPluginMessage request,
-        final Class<Subscription<? extends EventSource>> clazz, final String subscriptionID) {
+        final Class<? extends Subscription> clazz, final String
+            subscriptionID) {
         
         final FCPPluginMessage result =
             request != null ? FCPPluginMessage.constructSuccessReply(request) :
@@ -1338,10 +1339,10 @@ public final class FCPInterface implements FredPluginFCPMessageHandler.ServerSid
         final FCPPluginMessage fcpMessage = FCPPluginMessage.construct();
         
         fcpMessage.params.putOverwrite("Message", 
-             notification instanceof EndSynchronizationNotification 
+             notification instanceof EndSynchronizationNotification
                  ? "EndSynchronizationEvent" : "BeginSynchronizationEvent");
         
-        Subscription<? extends EventSource> subscription = notification.getSubscription();
+        Subscription<?> subscription = notification.getSubscription();
         String to;
         
         // The type parameter of the BeginSynchronizationNotification<T> is not known at runtime


### PR DESCRIPTION
Copy of the pull request on the repository of freenet since I don't have access to that repository anymore: https://github.com/freenet/plugin-WebOfTrust/pull/27

EDIT 2025-06-30:
 I have NOT forgotten about this PR! :)

The event-notifications API is currently just not the top priority, the priority is finishing the IdentityFetcher-rewrite which I have been working on for 85 branches now. Given it's been taking that many branches and thus that much time I do not want to get distracted too much, hence I've put this PR on hold.

I will deal with it once the IdentityFetcher-rewrite has been released.