### PR TITLE
Show Fred version from Gradle script

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -177,8 +177,6 @@ jobs:
         # TODO: Also print the checksums of other dependency JARs which Gradle has obtained from the
         # Internet or the local system.
         echo 'Checksums of fred JARs:' ; sha256sum ../fred/build/output/*
-        echo 'fred version:'
-        java -classpath '../fred/build/output/freenet.jar' 'freenet.node.Version'
         if [ "${{matrix.WoT-builder}}" = "ant" ] ; then
             ant clean && ant
         elif [ "${{matrix.WoT-builder}}" = "gradle" ] ; then

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,21 @@ task compileDb4o(type: Exec) {
 	                   "-Djavac.target.version=" + targetCompatibility
 }
 
+task showFredVersion {
+	doLast {
+		URL[] classpath = sourceSets.main.runtimeClasspath.files.collect { it.toURL() } as URL[]
+		def cl = new URLClassLoader(classpath)
+		def cls = Class.forName("freenet.node.Version", true, cl)
+		def publicVersion = cls.getMethod("publicVersion").invoke(null)
+		def buildNumber = cls.getMethod("buildNumber").invoke(null)
+		def cvsRevision = cls.getMethod("cvsRevision").invoke(null)
+		println("Using Fred version " + publicVersion + " build #" + buildNumber + " (" + cvsRevision + ")")
+	}
+}
+
 compileJava {
 	dependsOn 'compileDb4o'
+	dependsOn 'showFredVersion'
 }
 
 task prepareVersionFile(type: Copy) {


### PR DESCRIPTION
The workflow used to rely on Fred's freenet.node.Version having a main(...) method that prints the version information. That method has been removed, breaking this build.

Compile a version string in Gradle by invoking the related methods on the Version class.